### PR TITLE
Remove default CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,3 @@ VOLUME ["/app"]
 WORKDIR /app
 
 ENTRYPOINT ["/usr/local/bin/psysh"]
-CMD ["--help"]


### PR DESCRIPTION
I miss being able to do `./psysh`